### PR TITLE
Use single default PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,3 @@
----
-name: Generic Pull Request
-about: Submit an implementation for a specific issue
-
----
-
-
 | Related Links |
 | :--- |
 | [Helpful Link](https://google.com) |


### PR DESCRIPTION
# Description

Github supports multiple PR templates only via direct url parameter appending.
Meaning that there isn't a UI to select the PR template to use when creating a new pull request.

In this PR we simply revert to having only one template, thus removing the `PULL_REQUEST_TEMPLATE` folder.