### PR TITLE
Update junit to version 5.5.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.kotlinVersion = '1.3.30'
-    ext.junitVersion = "5.2.0"
+    ext.junitVersion = "5.5.1"
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
| Related Links |
| :--- |
| [Release Notes](https://junit.org/junit5/docs/5.5.0/release-notes/) |

 # Description
 Junit updated to version `5.5.1`. Bugfix release, the changelog in the links outlines `5.5` major changes.
